### PR TITLE
Removed local variable prependings.

### DIFF
--- a/src/fabric-1.16.5/procedures/read_json.java.ftl
+++ b/src/fabric-1.16.5/procedures/read_json.java.ftl
@@ -1,12 +1,12 @@
 {
 	try {
-		BufferedReader br = new BufferedReader(new FileReader(${input$var}));
+		BufferedReader bufferedReader = new BufferedReader(new FileReader(${input$var}));
 		StringBuilder jsonstringbuilder = new StringBuilder();
 		String line;
-		while((line = br.readLine()) != null) {
+		while((line = bufferedReader.readLine()) != null) {
 			jsonstringbuilder.append(line);
 		}
-		br.close();
+		bufferedReader.close();
 
 		JsonObject ${field$jVar} = new Gson().fromJson(jsonstringbuilder.toString(), JsonObject.class);
 		${statement$values}

--- a/src/fabric-1.16.5/procedures/write_json.java.ftl
+++ b/src/fabric-1.16.5/procedures/write_json.java.ftl
@@ -5,9 +5,9 @@
 	${statement$json}
 
 	try {
-  		FileWriter fw = new FileWriter(${input$var});
-  		fw.write(mainGSONBuilderVariable.toJson(${field$jvar}));
-  		fw.close();
+  		FileWriter fileWriter = new FileWriter(${input$var});
+  		fileWriter.write(mainGSONBuilderVariable.toJson(${field$jvar}));
+  		fileWriter.close();
 	} catch (IOException exception) {
   		exception.printStackTrace();
   	}	

--- a/src/forge-1.15.2/procedures/read_json.java.ftl
+++ b/src/forge-1.15.2/procedures/read_json.java.ftl
@@ -1,12 +1,12 @@
 {
 	try {
-		BufferedReader br = new BufferedReader(new FileReader(${input$var}));
+		BufferedReader bufferedReader = new BufferedReader(new FileReader(${input$var}));
 		StringBuilder jsonstringbuilder = new StringBuilder();
 		String line;
-		while((line = br.readLine()) != null) {
+		while((line = bufferedReader.readLine()) != null) {
 			jsonstringbuilder.append(line);
 		}
-		br.close();
+		bufferedReader.close();
 
 		JsonObject ${field$jVar} = new Gson().fromJson(jsonstringbuilder.toString(), JsonObject.class);
 		${statement$values}

--- a/src/forge-1.15.2/procedures/write_json.java.ftl
+++ b/src/forge-1.15.2/procedures/write_json.java.ftl
@@ -5,9 +5,9 @@
 	${statement$json}
 
 	try {
-  		FileWriter fw = new FileWriter(${input$var});
-  		fw.write(mainGSONBuilderVariable.toJson(${field$jvar}));
-  		fw.close();
+  		FileWriter fileWriter = new FileWriter(${input$var});
+  		fileWriter.write(mainGSONBuilderVariable.toJson(${field$jvar}));
+  		fileWriter.close();
 	} catch (IOException exception) {
   		exception.printStackTrace();
   	}	

--- a/src/forge-1.16.5/procedures/read_json.java.ftl
+++ b/src/forge-1.16.5/procedures/read_json.java.ftl
@@ -1,12 +1,12 @@
 {
 	try {
-		BufferedReader br = new BufferedReader(new FileReader(${input$var}));
+		BufferedReader bufferedReader = new BufferedReader(new FileReader(${input$var}));
 		StringBuilder jsonstringbuilder = new StringBuilder();
 		String line;
-		while((line = br.readLine()) != null) {
+		while((line = bufferedReader.readLine()) != null) {
 			jsonstringbuilder.append(line);
 		}
-		br.close();
+		bufferedReader.close();
 
 		JsonObject ${field$jVar} = new Gson().fromJson(jsonstringbuilder.toString(), JsonObject.class);
 		${statement$values}

--- a/src/forge-1.16.5/procedures/write_json.java.ftl
+++ b/src/forge-1.16.5/procedures/write_json.java.ftl
@@ -5,9 +5,9 @@
 	${statement$json}
 
 	try {
-  		FileWriter fw = new FileWriter(${input$var});
-  		fw.write(mainGSONBuilderVariable.toJson(${field$jvar}));
-  		fw.close();
+  		FileWriter fileWriter = new FileWriter(${input$var});
+  		fileWriter.write(mainGSONBuilderVariable.toJson(${field$jvar}));
+  		fileWriter.close();
 	} catch (IOException exception) {
   		exception.printStackTrace();
   	}	


### PR DESCRIPTION
Removed local variable prepending for file reader/writer in json
read and write routines to enable usage of global file variables.

FIxes #9 